### PR TITLE
Cleanup yum/dnf cache

### DIFF
--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -5,6 +5,8 @@ RUN \
     echo "skip_missing_names_on_install=False" >> /etc/yum.conf && \
     yum update -y && \
     yum install -y epel-release && \
-    yum install -y gcc git python python-devel python-pip python-virtualenv openssl-devel libselinux-python sudo
+    yum install -y gcc git python python-devel python-pip python-virtualenv openssl-devel libselinux-python sudo && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*
 
 ENV SHELL /bin/bash

--- a/centos8/Dockerfile
+++ b/centos8/Dockerfile
@@ -4,6 +4,8 @@ LABEL maintainer "PyContribs <pycontribs@googlegroups.com>"
 RUN \
     yum update -y && \
     yum install -y gcc git openssl-devel python3 python3-libselinux python3-devel python3-virtualenv sudo && \
-    ln -s /usr/bin/python3 /usr/bin/python
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*
 
 ENV SHELL /bin/bash


### PR DESCRIPTION
Avoids possible failure of running yum/dnf due to outdated cache and also
makes the container size smaller.

Error example:

Failed to synchronize cache for repo 'AppStream'