### PR TITLE
Add bash to alpine

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine:latest
 LABEL maintainer "PyContribs <pycontribs@googlegroups.com>"
 
 RUN \
-    apk add git python3 sudo
+    apk add git python3 sudo bash
 
 ENV SHELL /bin/bash


### PR DESCRIPTION
Bash is an assumed by many development tools and that is the main purpose
of these images.